### PR TITLE
fix(ipc): return IPC rejection to stop looping IPC failure

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -7,7 +7,7 @@ import { v4 } from "uuid";
 export async function findIPC(id = 0): Promise<Socket> {
   return new Promise((res, rej) => {
     let socket: Socket;
-    if (id > 9) rej(new Error("Failed to find Discord IPC"));
+    if (id > 9) return rej(new Error("Failed to find Discord IPC"));
     socket = connect(getIPCPath(id));
 
     socket.once("connect", () => {


### PR DESCRIPTION
Without the `return`, a failing IPC call caused by something like Discord not running rejects the `Promise` but continues to run, indefinitely attempting IPC connections for IDs above 9.

Simple fix to stop the loop. :)